### PR TITLE
Fix notice when listing non-existant documents

### DIFF
--- a/src/FirestoreDatabaseResource.php
+++ b/src/FirestoreDatabaseResource.php
@@ -60,9 +60,13 @@ class FirestoreDatabaseResource
 
         $response = $this->client->request('GET', 'documents/' . FirestoreHelper::normalizeCollection($collection), $options, $parameters);
 
-        $documents = array_map(function($doc) {
-            return new FirestoreDocument($doc);
-        }, $response['documents']);
+        if (isset($response['documents'])) {
+            $documents = array_map(function($doc) {
+                return new FirestoreDocument($doc);
+            }, $response['documents']);
+        } else {
+            $documents = [];
+        }
 
         return array_merge($response, [
             'documents' => $documents,

--- a/src/FirestoreDocument.php
+++ b/src/FirestoreDocument.php
@@ -36,11 +36,13 @@ class FirestoreDocument {
     {
         if (null !== $object) {
             $this->name       = $object['name'];
-            $this->createTime = $object['createTime'];
-            $this->updateTime = $object['updateTime'];
+            $this->createTime = isset($object['createTime']) ? $object['createTime'] : null;
+            $this->updateTime = isset($object['updateTime']) ? $object['updateTime'] : null;
 
-            foreach ($object['fields'] as $fieldName => $value) {
-                $this->fields[ $fieldName ] = $value;
+            if (isset($object['fields'])) {
+                foreach ($object['fields'] as $fieldName => $value) {
+                    $this->fields[ $fieldName ] = $value;
+                }
             }
         }
 


### PR DESCRIPTION
When listing documents with the parameter showMissing=true, non-existing
documents (that has sub-objects) will show up but will not have createTime,
updateTime of fields columns. This triggers an "Undefined index" notice
which some frameworks (laravel for instance) escalates to an ErrorException.